### PR TITLE
Add e2e traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ install(DIRECTORY include/
 
 install(PROGRAMS
   scripts/gantt.py
-  scripts/histogram.py
+  scripts/elapsed_time_histogram.py
+  scripts/execution_time_histogram.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/README.md
+++ b/README.md
@@ -405,8 +405,8 @@ ros2 run yaets executors     # In terminal 2
 Stop both processes and
 
 ```bash
-ros2 run yaest gantt.py ./session1.log --max_trazas 200
-ros2 run yaest histogram.py ../session1.log  --funcion ConsumerNode::timer_callback --bins 40
+ros2 run yaest gantt.py ./session1.log --max_traces 200
+ros2 run yaest histogram.py ../session1.log  --function ConsumerNode::timer_callback --bins 40
 ```
 And we get the two graphs:
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
       - [NamedSharedTrace](#namedsharedtrace)
       - [Using TraceRegistry to Manage Shared Traces by ID](#using-traceregistry-to-manage-shared-traces-by-id)
     - [Using Macros with NamedSharedTrace](#using-macros-with-namedsharedtrace)
+      - [Example 1](#example-1)
+      - [Example 2](#example-2)
     - [How It Works](#how-it-works)
       - [Key Methods](#key-methods)
     - [Python Gantt Chart Script](#python-gantt-chart-script)
@@ -173,6 +175,8 @@ int main() {
 
 To streamline the usage of `NamedSharedTrace` with `TraceRegistry`, YAETS provides macros for initializing, starting, and stopping traces by ID. This simplifies code readability and reduces the need to call methods directly on `TraceRegistry`.
 
+#### Example 1
+
 ```cpp
 include <yaets/tracing.hpp>
 
@@ -195,6 +199,37 @@ int main() {
     session.stop();
     return 0;
 }
+```
+
+
+#### Example 2
+
+```
+class SensorDriverNode : public rclcpp::Node
+{
+  ...
+  void produce_data()
+  {
+    SHARED_TRACE_START("brake_process");
+    waste_time(shared_from_this(), 200us);
+
+    sensor_msgs::msg::Image image_msg;
+    pub_->publish(image_msg);
+  }
+...
+class BrakeActuatorNode : public rclcpp::Node
+{
+  ...
+  void react_obstacle(vision_msgs::msg::Detection3D::SharedPtr msg)
+  {
+    waste_time(shared_from_this(), 2ms);
+    SHARED_TRACE_END("brake_process");
+  } 
+...
+int main(int argc, char * argv[])
+{
+  ...
+  SHARED_TRACE_INIT(session, "brake_process");
 ```
 
 ### How It Works

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
   - [Usage](#usage)
     - [C++ Tracing Library](#c-tracing-library)
       - [Example](#example)
+    - [Advanced Tracing with NamedSharedTrace and TraceRegistry](#advanced-tracing-with-namedsharedtrace-and-traceregistry)
+      - [NamedSharedTrace](#namedsharedtrace)
+      - [Using TraceRegistry to Manage Shared Traces by ID](#using-traceregistry-to-manage-shared-traces-by-id)
+    - [Using Macros with NamedSharedTrace](#using-macros-with-namedsharedtrace)
     - [How It Works](#how-it-works)
       - [Key Methods](#key-methods)
     - [Python Gantt Chart Script](#python-gantt-chart-script)
@@ -35,10 +39,6 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
       - [Usage](#usage-2)
       - [Options](#options-1)
   - [Building and Running Tests](#building-and-running-tests)
-    - [Advanced Tracing with NamedSharedTrace and TraceRegistry](#advanced-tracing-with-namedsharedtrace-and-traceregistry)
-      - [NamedSharedTrace](#namedsharedtrace)
-    - [Using TraceRegistry to Manage Shared Traces by ID](#using-traceregistry-to-manage-shared-traces-by-id)
-    - [Using Macros with NamedSharedTrace](#using-macros-with-namedsharedtrace)
   - [Tracing Session](#tracing-session)
     - [Code to trace:](#code-to-trace)
     - [Running and getting graphs](#running-and-getting-graphs)
@@ -114,10 +114,95 @@ int main() {
 }
 ```
 
+### Advanced Tracing with NamedSharedTrace and TraceRegistry
+
+For scenarios where you need to trace shared events across multiple parts of your application, you can use `NamedSharedTrace` and `TraceRegistry`.
+
+#### NamedSharedTrace
+
+The `NamedSharedTrace` class allows you to start and stop traces from different parts of the code, under a shared trace name.
+
+```cpp
+#include <yaets/tracing.hpp>
+
+int main() {
+    yaets::TraceSession session("shared_trace_output.log");
+
+    yaets::NamedSharedTrace trace1(session, "shared_event");
+    trace1.start();
+    // Perform operations
+    trace1.end();
+
+    session.stop();
+    return 0;
+}
+```
+
+#### Using TraceRegistry to Manage Shared Traces by ID
+
+With `TraceRegistry`, you can register and manage multiple `NamedSharedTrace` instances by ID, allowing you to start and stop traces throughout the application without directly referencing `NamedSharedTrace` objects.
+
+1. Initialize TraceRegistry: Register traces with IDs for centralized management.
+2. Start and Stop Traces by ID: Use macros to simplify starting and stopping traces.
+
+```cpp
+#include <yaets/tracing.hpp>
+
+int main() {
+    yaets::TraceSession session("registry_trace_output.log");
+
+    // Register traces with unique IDs
+    yaets::TraceRegistry::getInstance().registerTrace("trace1", session);
+    yaets::TraceRegistry::getInstance().registerTrace("trace2", session);
+
+    // Start and end traces by ID
+    yaets::TraceRegistry::getInstance().startTrace("trace1");
+    // Operations for trace1
+    yaets::TraceRegistry::getInstance().endTrace("trace1");
+
+    yaets::TraceRegistry::getInstance().startTrace("trace2");
+    // Operations for trace2
+    yaets::TraceRegistry::getInstance().endTrace("trace2");
+
+    session.stop();
+    return 0;
+}
+```
+
+### Using Macros with NamedSharedTrace
+
+To streamline the usage of `NamedSharedTrace` with `TraceRegistry`, YAETS provides macros for initializing, starting, and stopping traces by ID. This simplifies code readability and reduces the need to call methods directly on `TraceRegistry`.
+
+```cpp
+include <yaets/tracing.hpp>
+
+int main() {
+    yaets::TraceSession session("macro_trace_output.log");
+
+    // Initialize traces by ID
+    SHARED_TRACE_INIT(session, "macro_trace1");
+    SHARED_TRACE_INIT(session, "macro_trace2");
+
+    // Start and stop traces by ID
+    SHARED_TRACE_START("macro_trace1");
+    // Operations under macro_trace1
+    SHARED_TRACE_END("macro_trace1");
+
+    SHARED_TRACE_START("macro_trace2");
+    // Operations under macro_trace2
+    SHARED_TRACE_END("macro_trace2");
+
+    session.stop();
+    return 0;
+}
+```
+
 ### How It Works
 
 - **`TraceSession`**: Manages the tracing session and writes events asynchronously to a log file.
 - **`TraceGuard`**: Automatically traces the start and end of a function. It is created at the start of the function and destroyed when the function exits, capturing the execution time.
+- **`NamedSharedTrace`**: Allows you to create named traces that can be started and stopped independently across different parts of your code.
+- **`TraceRegistry`**: Provides centralized management of `NamedSharedTrace` instances, allowing you to register, start, and stop traces by ID.
 
 #### Key Methods
 
@@ -125,6 +210,12 @@ int main() {
 - `TraceSession::stop()`: Stops the session and writes any remaining events to the file.
 - `TraceGuard::TraceGuard(TraceSession & session, const std::string & function_name)`: Captures the function name and start time.
 - `TraceGuard::~TraceGuard()`: Logs the end time and registers the trace event.
+- `NamedSharedTrace::start()`: Begins a trace event.
+- `NamedSharedTrace::end()`: Ends a trace event and logs it to the associated TraceSession.
+- `TraceRegistry::registerTrace(const std::string& id, TraceSession& session)`: Registers a new trace with a unique ID.
+- `TraceRegistry::startTrace(const std::string& id)`: Starts a trace by its ID.
+- `TraceRegistry::endTrace(const std::string& id)`: Ends a trace by its ID.
+
 
 ### Python Gantt Chart Script
 
@@ -189,87 +280,7 @@ YAETS includes unit tests to verify the functionality of the tracing library. To
 
 This will run the tests in `tests/yaets_test.cpp` and verify the correctness of the tracing system.
 
-### Advanced Tracing with NamedSharedTrace and TraceRegistry
 
-For scenarios where you need to trace shared events across multiple parts of your application, you can use `NamedSharedTrace` and `TraceRegistry`.
-
-#### NamedSharedTrace
-
-The `NamedSharedTrace` class allows you to start and stop traces from different parts of the code, under a shared trace name.
-
-```cpp
-#include <yaets/tracing.hpp>
-
-int main() {
-    yaets::TraceSession session("shared_trace_output.log");
-
-    yaets::NamedSharedTrace trace1(session, "shared_event");
-    trace1.start();
-    // Perform operations
-    trace1.end();
-
-    session.stop();
-    return 0;
-}
-```
-
-### Using TraceRegistry to Manage Shared Traces by ID
-With `TraceRegistry`, you can register and manage multiple `NamedSharedTrace` instances by ID, allowing you to start and stop traces throughout the application without directly referencing `NamedSharedTrace` objects.
-
-1. Initialize TraceRegistry: Register traces with IDs for centralized management.
-2. Start and Stop Traces by ID: Use macros to simplify starting and stopping traces.
-
-```cpp
-#include <yaets/tracing.hpp>
-
-int main() {
-    yaets::TraceSession session("registry_trace_output.log");
-
-    // Register traces with unique IDs
-    yaets::TraceRegistry::getInstance().registerTrace("trace1", session);
-    yaets::TraceRegistry::getInstance().registerTrace("trace2", session);
-
-    // Start and end traces by ID
-    yaets::TraceRegistry::getInstance().startTrace("trace1");
-    // Operations for trace1
-    yaets::TraceRegistry::getInstance().endTrace("trace1");
-
-    yaets::TraceRegistry::getInstance().startTrace("trace2");
-    // Operations for trace2
-    yaets::TraceRegistry::getInstance().endTrace("trace2");
-
-    session.stop();
-    return 0;
-}
-```
-
-### Using Macros with NamedSharedTrace
-
-To streamline the usage of `NamedSharedTrace` with `TraceRegistry`, YAETS provides macros for initializing, starting, and stopping traces by ID. This simplifies code readability and reduces the need to call methods directly on `TraceRegistry`.
-
-```cpp
-include <yaets/tracing.hpp>
-
-int main() {
-    yaets::TraceSession session("macro_trace_output.log");
-
-    // Initialize traces by ID
-    SHARED_TRACE_INIT(session, "macro_trace1");
-    SHARED_TRACE_INIT(session, "macro_trace2");
-
-    // Start and stop traces by ID
-    SHARED_TRACE_START("macro_trace1");
-    // Operations under macro_trace1
-    SHARED_TRACE_END("macro_trace1");
-
-    SHARED_TRACE_START("macro_trace2");
-    // Operations under macro_trace2
-    SHARED_TRACE_END("macro_trace2");
-
-    session.stop();
-    return 0;
-}
-```
 
 ## Tracing Session
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
 
 ## Features
 
-- Function tracing using the `TraceSession` and `TraceGuard` classes.
+- Function tracing using the `TraceSession`, `TraceGuard`, `NamedSharedTrace`, and `TraceRegistry` classes.
 - Asynchronous logging of trace events to prevent performance overhead.
 - Python scripts to visualize traces as Gantt charts or analyze timing gaps between traces using histograms.
 
@@ -21,7 +21,8 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
   - [Table of Contents](#table-of-contents)
   - [Installation](#installation)
     - [Requirements](#requirements)
-    - [Building the C++ Library](#building-the-c-library)
+    - [Building the C++ Library without ROS](#building-the-c-library-without-ros)
+    - [Building the C++ Library with ROS 2](#building-the-c-library-with-ros-2)
   - [Usage](#usage)
     - [C++ Tracing Library](#c-tracing-library)
       - [Example](#example)
@@ -34,6 +35,13 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
       - [Usage](#usage-2)
       - [Options](#options-1)
   - [Building and Running Tests](#building-and-running-tests)
+    - [Advanced Tracing with NamedSharedTrace and TraceRegistry](#advanced-tracing-with-namedsharedtrace-and-traceregistry)
+      - [NamedSharedTrace](#namedsharedtrace)
+    - [Using TraceRegistry to Manage Shared Traces by ID](#using-traceregistry-to-manage-shared-traces-by-id)
+    - [Using Macros with NamedSharedTrace](#using-macros-with-namedsharedtrace)
+  - [Tracing Session](#tracing-session)
+    - [Code to trace:](#code-to-trace)
+    - [Running and getting graphs](#running-and-getting-graphs)
   - [License](#license)
 
 ## Installation
@@ -180,6 +188,88 @@ YAETS includes unit tests to verify the functionality of the tracing library. To
     ```
 
 This will run the tests in `tests/yaets_test.cpp` and verify the correctness of the tracing system.
+
+### Advanced Tracing with NamedSharedTrace and TraceRegistry
+
+For scenarios where you need to trace shared events across multiple parts of your application, you can use `NamedSharedTrace` and `TraceRegistry`.
+
+#### NamedSharedTrace
+
+The `NamedSharedTrace` class allows you to start and stop traces from different parts of the code, under a shared trace name.
+
+```cpp
+#include <yaets/tracing.hpp>
+
+int main() {
+    yaets::TraceSession session("shared_trace_output.log");
+
+    yaets::NamedSharedTrace trace1(session, "shared_event");
+    trace1.start();
+    // Perform operations
+    trace1.end();
+
+    session.stop();
+    return 0;
+}
+```
+
+### Using TraceRegistry to Manage Shared Traces by ID
+With `TraceRegistry`, you can register and manage multiple `NamedSharedTrace` instances by ID, allowing you to start and stop traces throughout the application without directly referencing `NamedSharedTrace` objects.
+
+1. Initialize TraceRegistry: Register traces with IDs for centralized management.
+2. Start and Stop Traces by ID: Use macros to simplify starting and stopping traces.
+
+```cpp
+#include <yaets/tracing.hpp>
+
+int main() {
+    yaets::TraceSession session("registry_trace_output.log");
+
+    // Register traces with unique IDs
+    yaets::TraceRegistry::getInstance().registerTrace("trace1", session);
+    yaets::TraceRegistry::getInstance().registerTrace("trace2", session);
+
+    // Start and end traces by ID
+    yaets::TraceRegistry::getInstance().startTrace("trace1");
+    // Operations for trace1
+    yaets::TraceRegistry::getInstance().endTrace("trace1");
+
+    yaets::TraceRegistry::getInstance().startTrace("trace2");
+    // Operations for trace2
+    yaets::TraceRegistry::getInstance().endTrace("trace2");
+
+    session.stop();
+    return 0;
+}
+```
+
+### Using Macros with NamedSharedTrace
+
+To streamline the usage of `NamedSharedTrace` with `TraceRegistry`, YAETS provides macros for initializing, starting, and stopping traces by ID. This simplifies code readability and reduces the need to call methods directly on `TraceRegistry`.
+
+```cpp
+include <yaets/tracing.hpp>
+
+int main() {
+    yaets::TraceSession session("macro_trace_output.log");
+
+    // Initialize traces by ID
+    SHARED_TRACE_INIT(session, "macro_trace1");
+    SHARED_TRACE_INIT(session, "macro_trace2");
+
+    // Start and stop traces by ID
+    SHARED_TRACE_START("macro_trace1");
+    // Operations under macro_trace1
+    SHARED_TRACE_END("macro_trace1");
+
+    SHARED_TRACE_START("macro_trace2");
+    // Operations under macro_trace2
+    SHARED_TRACE_END("macro_trace2");
+
+    session.stop();
+    return 0;
+}
+```
 
 ## Tracing Session
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ YAETS is a library designed to trace function execution in C++ asynchronously, c
     - [Python Gantt Chart Script](#python-gantt-chart-script)
       - [Usage](#usage-1)
       - [Options](#options)
-    - [Python Histogram Script](#python-histogram-script)
+    - [Python Histogram Script for ellapsed time](#python-histogram-script-for-ellapsed-time)
       - [Usage](#usage-2)
       - [Options](#options-1)
+    - [Python Histogram Script for execution time](#python-histogram-script-for-execution-time)
+      - [Usage](#usage-3)
+      - [Options](#options-2)
   - [Building and Running Tests](#building-and-running-tests)
   - [Tracing Session](#tracing-session)
     - [Code to trace:](#code-to-trace)
@@ -274,19 +277,19 @@ The Python script `gantt.py` allows you to visualize the traced functions as a G
   
 The resulting Gantt chart shows each function's execution times, allowing you to visualize the sequence and duration of function calls.
 
-### Python Histogram Script
+### Python Histogram Script for ellapsed time
 
-The Python script `histogram.py` analyzes the intervals between function executions and visualizes them as a histogram.
+The Python script `elaspsed_histogram.py` analyzes the intervals between function executions and visualizes them as a histogram.
 
 #### Usage
 
-1. Run the `histogram.py` script, specifying the function name you want to analyze:
+1. Run the `elaspsed_histogram.py` script, specifying the function name you want to analyze:
     ```bash
-    python3 scripts/histogram.py trace_output.log --function example_function --bins 50
+    python3 scripts/elaspsed_histogram.py trace_output.log --function example_function --bins 50
     ```
     or altenativelly
      ```bash
-    ros2 run yaest histogram.py trace_output.log --function example_function --bins 50
+    ros2 run yaest elaspsed_histogram.py trace_output.log --function example_function --bins 50
     ```
 
 
@@ -296,6 +299,28 @@ The Python script `histogram.py` analyzes the intervals between function executi
 - `--bins`: The number of bins for the histogram (to control the resolution).
 
 This tool helps you understand how frequently functions are called and whether there are patterns in the execution intervals.
+
+### Python Histogram Script for execution time
+
+The Python script `execution_histogram.py` analyzes execution time of a function and visualizes them as a histogram.
+
+#### Usage
+
+1. Run the `execution_histogram.py` script, specifying the function name you want to analyze:
+    ```bash
+    python3 scripts/execution_histogram.py trace_output.log --function example_function --bins 50
+    ```
+    or altenativelly
+     ```bash
+    ros2 run yaest execution_histogram.py trace_output.log --function example_function --bins 50
+    ```
+
+
+#### Options
+
+- `--function`: The name of the function whose execution execution time you want to analyze.
+- `--bins`: The number of bins for the histogram (to control the resolution).
+
 
 ## Building and Running Tests
 
@@ -441,7 +466,7 @@ Stop both processes and
 
 ```bash
 ros2 run yaest gantt.py ./session1.log --max_traces 200
-ros2 run yaest histogram.py ../session1.log  --function ConsumerNode::timer_callback --bins 40
+ros2 run yaest elaspsed_histogram.py ../session1.log  --function ConsumerNode::timer_callback --bins 40
 ```
 And we get the two graphs:
 

--- a/include/yaets/tracing.hpp
+++ b/include/yaets/tracing.hpp
@@ -269,7 +269,8 @@ private:
  * identified by unique IDs, allowing traces to be started and ended globally
  * through macros and without explicit object references.
  */
-class TraceRegistry {
+class TraceRegistry
+{
 public:
   /**
    * @brief Retrieve the singleton instance of the TraceRegistry.

--- a/include/yaets/tracing.hpp
+++ b/include/yaets/tracing.hpp
@@ -22,6 +22,8 @@
 #include <condition_variable>
 #include <thread>
 #include <atomic>
+#include <unordered_map>
+#include <memory>
 
 namespace yaets
 {
@@ -41,6 +43,42 @@ namespace yaets
     #define TRACE_EVENT(session) yaets::TraceGuard trace_guard(session, __FUNCTION__)
 #endif
 
+
+/**
+ * @brief Macro to initialize a shared trace with a unique identifier.
+ *
+ * This macro registers a new NamedSharedTrace instance with the global
+ * TraceRegistry, associated with the provided TraceSession.
+ *
+ * @param session The TraceSession to associate with the trace.
+ * @param id The unique identifier for the trace.
+ */
+#define SHARED_TRACE_INIT(session, id) \
+  yaets::TraceRegistry::getInstance().registerTrace(id, session)
+
+/**
+ * @brief Macro to start a shared trace by its unique identifier.
+ *
+ * This macro starts the NamedSharedTrace instance associated with the
+ * provided trace identifier.
+ *
+ * @param id The unique identifier for the trace.
+ */
+#define SHARED_TRACE_START(id) \
+  yaets::TraceRegistry::getInstance().startTrace(id)
+
+/**
+ * @brief Macro to end a shared trace by its unique identifier.
+ *
+ * This macro ends the NamedSharedTrace instance associated with the
+ * provided trace identifier.
+ *
+ * @param id The unique identifier for the trace.
+ */
+#define SHARED_TRACE_END(id) \
+  yaets::TraceRegistry::getInstance().endTrace(id)
+
+
 /**
  * @brief Structure to represent a trace event.
  *
@@ -49,7 +87,7 @@ namespace yaets
  */
 struct TraceEvent
 {
-  std::string function_name;                  ///< Name of the traced function.
+  std::string trace_name;                  ///< Name of the traced function.
   std::chrono::nanoseconds start_time;        ///< Start time of the function in nanoseconds.
   std::chrono::nanoseconds end_time;          ///< End time of the function in nanoseconds.
 };
@@ -87,12 +125,12 @@ public:
    * This function is called by TraceGuard to register the start and end
    * time of a function execution.
    *
-   * @param function_name The name of the function being traced.
+   * @param trace_name The name of the function being traced.
    * @param start_time The start time of the function execution.
    * @param end_time The end time of the function execution.
    */
   void register_trace(
-    const std::string & function_name,
+    const std::string & trace_name,
     const std::chrono::nanoseconds & start_time,
     const std::chrono::nanoseconds & end_time);
 
@@ -130,9 +168,9 @@ public:
    * This constructor captures the function name and the start time of the function.
    *
    * @param session The TraceSession to register the trace event with.
-   * @param function_name The name of the function being traced.
+   * @param trace_name The name of the function being traced.
    */
-  TraceGuard(TraceSession & session, const std::string & function_name);
+  TraceGuard(TraceSession & session, const std::string & trace_name);
 
   /**
    * @brief Destroy the TraceGuard object.
@@ -142,9 +180,22 @@ public:
    */
   ~TraceGuard();
 
+  /**
+   * @brief Retrieve the start time of the trace.
+   *
+   * This getter provides read-only access to the start time recorded
+   * by the `TraceGuard` at the beginning of a traced function execution.
+   *
+   * @return The start time of the function execution as a `std::chrono::nanoseconds` duration.
+   */
+  std::chrono::nanoseconds get_start_time() const
+  {
+    return start_time_;
+  }
+
 private:
   TraceSession & session_;                    ///< The TraceSession associated with this trace.
-  std::string function_name_;                 ///< The name of the function being traced.
+  std::string trace_name_;                 ///< The name of the function being traced.
   std::chrono::nanoseconds start_time_;       ///< The start time of the function execution.
 
 protected:
@@ -157,7 +208,125 @@ protected:
    * @param function_signature The full function signature.
    * @return The extracted function name.
    */
-  std::string extract_function_name(const std::string & function_signature);
+  std::string extract_trace_name(const std::string & function_signature);
+};
+
+
+/**
+ * @brief Class to manage shared traces across different parts of the code.
+ *
+ * The NamedSharedTrace class allows tracing events that can occur in
+ * various parts of the code and logs both start and end times to a shared
+ * TraceSession. It supports concurrent operations and capacity handling.
+ */
+class NamedSharedTrace
+{
+public:
+  static const size_t TRACE_SIZE_INIT = 100; ///< Initial size for the start_times_ vector.
+
+  /**
+   * @brief Construct a new NamedSharedTrace object.
+   *
+   * Initializes a named trace session that can be started and ended across
+   * different locations.
+   *
+   * @param session The TraceSession associated with the trace events.
+   * @param trace_name The name of the trace event being recorded.
+   */
+  NamedSharedTrace(TraceSession & session, const std::string & trace_name);
+
+  /**
+   * @brief Start a new trace event.
+   *
+   * Records the start time of a trace event in a thread-safe manner.
+   */
+  void start();
+
+  /**
+   * @brief End the current trace event.
+   *
+   * Records the end time of a trace event and registers it with the
+   * TraceSession. Ensures that a corresponding start time exists.
+   */
+  void end();
+
+private:
+  TraceSession & session_;                        ///< Reference to the associated TraceSession.
+  std::string trace_name_;                        ///< The name of the traced event.
+  std::vector<std::chrono::nanoseconds> start_times_; ///< Stores start times for trace events.
+
+  std::atomic<size_t> counter_push_;              ///< Tracks the number of start events.
+  std::atomic<size_t> counter_pop_;               ///< Tracks the number of end events.
+  size_t elements_;                               ///< Current number of elements in start_times_.
+  std::mutex trace_mutex_;                        ///< Mutex to ensure thread-safe operations on start_times_.
+};
+
+
+/**
+ * @brief Singleton class to manage global NamedSharedTrace instances.
+ *
+ * The TraceRegistry maintains a collection of NamedSharedTrace instances,
+ * identified by unique IDs, allowing traces to be started and ended globally
+ * through macros and without explicit object references.
+ */
+class TraceRegistry {
+public:
+  /**
+   * @brief Retrieve the singleton instance of the TraceRegistry.
+   *
+   * This function returns the single, globally accessible instance of
+   * the TraceRegistry.
+   *
+   * @return The singleton instance of TraceRegistry.
+   */
+  static TraceRegistry & getInstance()
+  {
+    static TraceRegistry instance;
+    return instance;
+  }
+
+  /**
+   * @brief Register a new NamedSharedTrace with a unique identifier.
+   *
+   * This function registers a NamedSharedTrace instance associated with
+   * a given ID and TraceSession, allowing the trace to be managed globally.
+   *
+   * @param id The unique identifier for the trace.
+   * @param session The TraceSession associated with the trace.
+   */
+  void registerTrace(const std::string & id, TraceSession & session);
+
+  /**
+   * @brief Start a trace identified by a unique ID.
+   *
+   * This function starts the NamedSharedTrace associated with the given
+   * ID, marking the beginning of a traced section.
+   *
+   * @param id The unique identifier for the trace to start.
+   */
+  void startTrace(const std::string & id);
+
+  /**
+   * @brief End a trace identified by a unique ID.
+   *
+   * This function ends the NamedSharedTrace associated with the given
+   * ID, marking the end of a traced section.
+   *
+   * @param id The unique identifier for the trace to end.
+   */
+  void endTrace(const std::string & id);
+
+private:
+  std::unordered_map<std::string, std::unique_ptr<NamedSharedTrace>> traces_; ///< Stores traces by unique ID.
+  std::mutex mutex_; ///< Mutex for synchronizing access to the trace map.
+
+  // Private constructors for singleton pattern
+  TraceRegistry() = default;
+  ~TraceRegistry() = default;
+
+  // Disable copy construction and assignment
+  TraceRegistry(const TraceRegistry &) = delete;
+  TraceRegistry & operator=(const TraceRegistry &) = delete;
 };
 
 }  // namespace yaets

--- a/scripts/elapsed_time_histogram.py
+++ b/scripts/elapsed_time_histogram.py
@@ -53,7 +53,7 @@ def calculate_intervals_between_starts(traces):
     return intervals
 
 
-def create_histogram(intervals, target_function, num_bins):
+def create_elapsed_time_histogram(intervals, target_function, num_bins):
     plt.hist(intervals, bins=num_bins, edgecolor='black', log=True)
     plt.xlabel('Interval between starts (ms)')
     plt.ylabel('Frequency (log scale)')
@@ -85,7 +85,7 @@ def main():
 
     intervals = calculate_intervals_between_starts(function_traces)
 
-    create_histogram(intervals, args.function, args.bins)
+    create_elapsed_time_histogram(intervals, args.function, args.bins)
 
 
 if __name__ == '__main__':

--- a/scripts/execution_time_histogram.py
+++ b/scripts/execution_time_histogram.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+
+# Copyright 2024 Intelligent Robotics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+import matplotlib.pyplot as plt
+
+
+def ns_to_ms(ns):
+    return ns / 1_000_000
+
+
+def read_traces(trace_file, function_name, max_traces=None):
+    execution_times = []
+    with open(trace_file, 'r') as file:
+        for i, line in enumerate(file):
+            if max_traces and i >= max_traces:
+                break
+            parts = line.split()
+            if len(parts) == 3:
+                function = parts[0]
+                start_ns = int(parts[1])
+                end_ns = int(parts[2])
+                if function == function_name:
+                    duration_ms = ns_to_ms(end_ns - start_ns)
+                    execution_times.append(duration_ms)
+    return execution_times
+
+
+def create_execution_time_histogram(execution_times, function_name, num_bins):
+    plt.hist(execution_times, bins=num_bins, edgecolor='black', log=True)
+    plt.xlabel('Execution Time (ms)')
+    plt.ylabel('Frequency (log scale)')
+    plt.title(f'Execution Time Histogram for "{function_name}"')
+    plt.grid(True, linestyle=':', linewidth=0.5)
+    plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate a histogram of execution times for a specific function.')
+    parser.add_argument('trace_file', type=str, help='Trace file to process')
+    parser.add_argument(
+        '--function', type=str, required=True, help='Name of the function for the histogram')
+    parser.add_argument(
+        '--max_traces', type=int, default=None, help='Maximum number of traces to display')
+    parser.add_argument(
+        '--bins', type=int, default=10,
+        help='Number of bins (X-axis resolution) for the histogram')
+
+    args = parser.parse_args()
+
+    execution_times = read_traces(args.trace_file, args.function, args.max_traces)
+
+    if not execution_times:
+        print(f"No execution times found for function '{args.function}'.")
+        return
+
+    create_execution_time_histogram(execution_times, args.function, args.bins)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/gantt.py
+++ b/scripts/gantt.py
@@ -62,16 +62,15 @@ def create_gantt_chart(traces):
         for start_ms, duration_ms in grouped_traces[function]:
             ax.barh(i, duration_ms, left=start_ms, height=0.4, color=colors_by_function[function])
 
-    ax.set_xlabel('Time (ms)', fontsize=24)
-    ax.set_title('Gantt Chart of Traced Executions', fontsize=28)
+    ax.set_xlabel('Time (ms)')
+    ax.set_title('Gantt Chart of Traced Executions')
 
     split_labels = split_labels_by_delimiter(functions)
     ax.set_yticks(range(len(split_labels)))
-    ax.set_yticklabels(split_labels, fontsize=18)
+    ax.set_yticklabels(split_labels)
 
     ax.grid(True, linestyle=':', linewidth=0.5)
 
-    plt.xticks(fontsize=18)
     plt.show()
 
 

--- a/scripts/gantt.py
+++ b/scripts/gantt.py
@@ -14,16 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import argparse
-
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
-
+from collections import defaultdict
 
 def ns_to_ms(ns):
     return ns / 1_000_000
-
 
 def read_traces(trace_file, max_traces=None):
     traces = []
@@ -41,25 +38,41 @@ def read_traces(trace_file, max_traces=None):
                 traces.append((function, start_ms, duration_ms))
     return traces
 
+# Function to split Y-axis labels based on "::" delimiter
+def split_labels_by_delimiter(labels, delimiter="::"):
+    return [label.replace(delimiter, "\n") for label in labels]
 
 def create_gantt_chart(traces):
-    functions = list({function for function, _, _ in traces})
+    # Group traces by function
+    grouped_traces = defaultdict(list)
+    for function, start_ms, duration_ms in traces:
+        grouped_traces[function].append((start_ms, duration_ms))
+
+    # Prepare function names and colors
+    functions = list(grouped_traces.keys())
     colors = cm.get_cmap('tab10', len(functions))
-    colors_by_function = {function: colors(i) for i, function in enumerate(functions)}
+    colors_by_function = {function: colors(i / len(functions)) for i, function in enumerate(functions)}
 
     fig, ax = plt.subplots(figsize=(10, 6))
 
-    for i, (function, start_ms, duration_ms) in enumerate(traces):
-        ax.barh(function, duration_ms, left=start_ms, height=0.4,
-                color=colors_by_function[function])
+    # Plot each function on a separate row
+    for i, function in enumerate(functions):
+        for start_ms, duration_ms in grouped_traces[function]:
+            ax.barh(i, duration_ms, left=start_ms, height=0.4, color=colors_by_function[function])
 
-    ax.set_xlabel('Time (ms)')
-    ax.set_ylabel('Functions')
-    ax.set_title('Gantt Chart of Traced Executions')
+    # Apply labels
+    ax.set_xlabel('Time (ms)', fontsize=24)
+    ax.set_title('Gantt Chart of Traced Executions', fontsize=28)
+
+    # Split function names by "::" and set them as Y-tick labels
+    split_labels = split_labels_by_delimiter(functions)
+    ax.set_yticks(range(len(split_labels)))
+    ax.set_yticklabels(split_labels, fontsize=18)
+
     ax.grid(True, linestyle=':', linewidth=0.5)
 
+    plt.xticks(fontsize=18)  # X-axis tick labels
     plt.show()
-
 
 def main():
     parser = argparse.ArgumentParser(description='Generate a Gantt chart from a trace file.')
@@ -72,7 +85,6 @@ def main():
     traces = read_traces(args.trace_file, args.max_traces)
 
     create_gantt_chart(traces)
-
 
 if __name__ == '__main__':
     main()

--- a/scripts/gantt.py
+++ b/scripts/gantt.py
@@ -15,12 +15,15 @@
 # limitations under the License.
 
 import argparse
+from collections import defaultdict
+
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
-from collections import defaultdict
+
 
 def ns_to_ms(ns):
     return ns / 1_000_000
+
 
 def read_traces(trace_file, max_traces=None):
     traces = []
@@ -38,41 +41,39 @@ def read_traces(trace_file, max_traces=None):
                 traces.append((function, start_ms, duration_ms))
     return traces
 
-# Function to split Y-axis labels based on "::" delimiter
-def split_labels_by_delimiter(labels, delimiter="::"):
-    return [label.replace(delimiter, "\n") for label in labels]
+
+def split_labels_by_delimiter(labels, delimiter='::'):
+    return [label.replace(delimiter, '\n') for label in labels]
+
 
 def create_gantt_chart(traces):
-    # Group traces by function
     grouped_traces = defaultdict(list)
     for function, start_ms, duration_ms in traces:
         grouped_traces[function].append((start_ms, duration_ms))
 
-    # Prepare function names and colors
     functions = list(grouped_traces.keys())
     colors = cm.get_cmap('tab10', len(functions))
-    colors_by_function = {function: colors(i / len(functions)) for i, function in enumerate(functions)}
+    colors_by_function = {function: colors(i / len(functions)) for i,
+                          function in enumerate(functions)}
 
     fig, ax = plt.subplots(figsize=(10, 6))
 
-    # Plot each function on a separate row
     for i, function in enumerate(functions):
         for start_ms, duration_ms in grouped_traces[function]:
             ax.barh(i, duration_ms, left=start_ms, height=0.4, color=colors_by_function[function])
 
-    # Apply labels
     ax.set_xlabel('Time (ms)', fontsize=24)
     ax.set_title('Gantt Chart of Traced Executions', fontsize=28)
 
-    # Split function names by "::" and set them as Y-tick labels
     split_labels = split_labels_by_delimiter(functions)
     ax.set_yticks(range(len(split_labels)))
     ax.set_yticklabels(split_labels, fontsize=18)
 
     ax.grid(True, linestyle=':', linewidth=0.5)
 
-    plt.xticks(fontsize=18)  # X-axis tick labels
+    plt.xticks(fontsize=18)
     plt.show()
+
 
 def main():
     parser = argparse.ArgumentParser(description='Generate a Gantt chart from a trace file.')
@@ -85,6 +86,7 @@ def main():
     traces = read_traces(args.trace_file, args.max_traces)
 
     create_gantt_chart(traces)
+
 
 if __name__ == '__main__':
     main()

--- a/src/yaets/tracing.cpp
+++ b/src/yaets/tracing.cpp
@@ -54,12 +54,12 @@ TraceSession::stop()
 
 void
 TraceSession::register_trace(
-  const std::string & function_name,
+  const std::string & trace_name,
   const std::chrono::nanoseconds & start_time,
   const std::chrono::nanoseconds & end_time)
 {
   TraceEvent event;
-  event.function_name = function_name;
+  event.trace_name = trace_name;
   event.start_time = start_time - session_start_time_;
   event.end_time = end_time - session_start_time_;
 
@@ -84,7 +84,7 @@ TraceSession::trace_consumer()
       TraceEvent event = trace_queue.front();
       trace_queue.pop();
 
-      trace_file << event.function_name
+      trace_file << event.trace_name
                  << " " << event.start_time.count()
                  << " " << event.end_time.count() << "\n";
     }
@@ -93,8 +93,8 @@ TraceSession::trace_consumer()
   trace_file.close();
 }
 
-TraceGuard::TraceGuard(TraceSession & session, const std::string & function_name)
-: session_(session), function_name_(extract_function_name(function_name)),
+TraceGuard::TraceGuard(TraceSession & session, const std::string & trace_name)
+: session_(session), trace_name_(extract_trace_name(trace_name)),
   start_time_(std::chrono::high_resolution_clock::now().time_since_epoch())
 {
 }
@@ -102,12 +102,12 @@ TraceGuard::TraceGuard(TraceSession & session, const std::string & function_name
 TraceGuard::~TraceGuard()
 {
   auto end_time = std::chrono::high_resolution_clock::now().time_since_epoch();
-  session_.register_trace(function_name_, start_time_, end_time);
+  session_.register_trace(trace_name_, start_time_, end_time);
 }
 
 
 std::string
-TraceGuard::extract_function_name(const std::string & function_signature)
+TraceGuard::extract_trace_name(const std::string & function_signature)
 {
   std::string result = function_signature;
 
@@ -122,6 +122,68 @@ TraceGuard::extract_function_name(const std::string & function_signature)
   }
 
   return result;
+}
+
+NamedSharedTrace::NamedSharedTrace(TraceSession & session, const std::string & trace_name)
+: session_(session), trace_name_(trace_name),
+  counter_push_(0), counter_pop_(0), elements_(0), start_times_(TRACE_SIZE_INIT)
+{
+}
+
+void
+NamedSharedTrace::start()
+{
+  std::lock_guard<std::mutex> lock(trace_mutex_);
+
+  if (elements_ >= start_times_.size()) {
+    std::cerr << "Warning: Start times vector is full. Cannot start new trace." << std::endl;
+    return;
+  }
+  elements_++;
+
+  start_times_[counter_push_] = std::chrono::high_resolution_clock::now().time_since_epoch();
+  counter_push_ = (counter_push_ + 1) % start_times_.size();
+}
+
+void
+NamedSharedTrace::end()
+{
+  std::lock_guard<std::mutex> lock(trace_mutex_);
+
+  if (elements_ == 0) {
+    std::cerr << "Warning: No matching start() call for end() - ignoring." << std::endl;
+    return;
+  }
+
+  auto end_time = std::chrono::high_resolution_clock::now().time_since_epoch();
+  session_.register_trace(trace_name_, start_times_[counter_pop_], end_time);
+  counter_pop_ = (counter_pop_ + 1) % start_times_.size();
+  elements_--;
+}
+
+void
+TraceRegistry::registerTrace(const std::string & id, TraceSession & session)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  traces_[id] = std::make_unique<NamedSharedTrace>(session, id);
+}
+
+void
+TraceRegistry::startTrace(const std::string & id)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (traces_.count(id)) {
+    traces_[id]->start();
+  }
+}
+
+void
+TraceRegistry::endTrace(const std::string & id)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (traces_.count(id)) {
+    traces_[id]->end();
+  }
 }
 
 }  // namespace yaets

--- a/tests/yaets_test.cpp
+++ b/tests/yaets_test.cpp
@@ -1,45 +1,153 @@
-// Copyright 2024 Intelligent Robotics Lab
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-
 #include "yaets/tracing.hpp"
-
 #include "gtest/gtest.h"
+#include <fstream>
+#include <thread>
+#include <chrono>
 
-
-class TraceGuardTest : public yaets::TraceGuard
-{
+class TraceGuardTest : public yaets::TraceGuard {
 public:
-  TraceGuardTest(yaets::TraceSession & session, const std::string & function_name)
-  : TraceGuard(session, function_name)
-  {
-  }
+  TraceGuardTest(yaets::TraceSession & session, const std::string & trace_name)
+  : TraceGuard(session, trace_name) {}
 
-  std::string extract_function_name_test(const std::string & function_signature)
+  std::string extract_trace_name_test(const std::string & function_signature)
   {
-    return extract_function_name(function_signature);
+    return extract_trace_name(function_signature);
   }
 };
 
+TEST(yaets, TraceSessionInitStop) {
+  yaets::TraceSession trace_session("test_trace.log");
+  std::ofstream file("test_trace.log");
+  ASSERT_TRUE(file.is_open());
+  file.close();
+  trace_session.stop();
+  std::remove("test_trace.log");
+}
 
-TEST(yaets, extract_function_name)
-{
+TEST(yaets, TraceSessionWriteEvent) {
+  yaets::TraceSession trace_session("test_trace_event.log");
+  trace_session.register_trace("testFunction", std::chrono::nanoseconds(100),
+    std::chrono::nanoseconds(200));
+  trace_session.stop();
+  std::ifstream file("test_trace_event.log");
+  ASSERT_TRUE(file.is_open());
+  std::string line;
+  ASSERT_TRUE(std::getline(file, line));
+  EXPECT_FALSE(line.empty());
+  file.close();
+  std::remove("test_trace_event.log");
+}
+
+TEST(yaets, TraceGuardNameExtraction) {
   yaets::TraceSession trace_session("no_file.log");
   TraceGuardTest trace_guard(trace_session, "no_file");
+  ASSERT_EQ(trace_guard.extract_trace_name_test("function_1(std::string args)"), "function_1");
+  ASSERT_EQ(trace_guard.extract_trace_name_test("function_1()"), "function_1");
+}
 
-  ASSERT_EQ(trace_guard.extract_function_name_test("function_1(std::string args)"), "function_1");
-  ASSERT_EQ(trace_guard.extract_function_name_test("function_1()"), "function_1");
+TEST(yaets, TraceGuardStartEndTimes) {
+  yaets::TraceSession trace_session("test_guard_times.log");
+  {
+    yaets::TraceGuard trace_guard(trace_session, "testFunction");
+    auto now = std::chrono::high_resolution_clock::now().time_since_epoch();
+    ASSERT_LE(trace_guard.get_start_time().count(), now.count());
+  }
+  trace_session.stop();
+  std::remove("test_guard_times.log");
+}
+
+TEST(yaets, NamedSharedTraceBasic) {
+  yaets::TraceSession trace_session("test_named_trace.log");
+  yaets::NamedSharedTrace shared_trace(trace_session, "sharedFunction");
+  shared_trace.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  shared_trace.end();
+  trace_session.stop();
+  std::remove("test_named_trace.log");
+}
+
+TEST(yaets, NamedSharedTraceOverCapacity) {
+  yaets::TraceSession trace_session("test_over_capacity.log");
+  yaets::NamedSharedTrace shared_trace(trace_session, "overCapacityFunction");
+  for (size_t i = 0; i < shared_trace.TRACE_SIZE_INIT + 5; ++i) {
+    shared_trace.start();
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
+    shared_trace.end();
+  }
+  trace_session.stop();
+  std::ifstream file("test_over_capacity.log");
+  ASSERT_TRUE(file.is_open());
+  std::string line;
+  ASSERT_TRUE(std::getline(file, line));
+  EXPECT_FALSE(line.empty());
+  file.close();
+  std::remove("test_over_capacity.log");
+}
+
+TEST(yaets, TraceRegistrySingleTrace) {
+  yaets::TraceSession session("test_trace_registry.log");
+  yaets::TraceRegistry & registry = yaets::TraceRegistry::getInstance();
+  registry.registerTrace("trace1", session);
+  registry.startTrace("trace1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  registry.endTrace("trace1");
+  session.stop();
+  std::ifstream file("test_trace_registry.log");
+  ASSERT_TRUE(file.is_open());
+  std::string line;
+  ASSERT_TRUE(std::getline(file, line));
+  EXPECT_FALSE(line.empty());
+  file.close();
+  std::remove("test_trace_registry.log");
+}
+
+TEST(yaets, TraceRegistryMultipleTraces) {
+  yaets::TraceSession session("test_multiple_traces.log");
+  yaets::TraceRegistry & registry = yaets::TraceRegistry::getInstance();
+  registry.registerTrace("trace1", session);
+  registry.registerTrace("trace2", session);
+  registry.startTrace("trace1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  registry.endTrace("trace1");
+  registry.startTrace("trace2");
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  registry.endTrace("trace2");
+  session.stop();
+  std::ifstream file("test_multiple_traces.log");
+  ASSERT_TRUE(file.is_open());
+  std::string line;
+  int count = 0;
+  while (std::getline(file, line)) {
+    EXPECT_FALSE(line.empty());
+    ++count;
+  }
+  EXPECT_EQ(count, 2);
+  file.close();
+  std::remove("test_multiple_traces.log");
+}
+
+TEST(yaets, MacroSharedTrace) {
+  yaets::TraceSession session("test_macro_trace.log");
+  SHARED_TRACE_INIT(session, "macro_trace1");
+  SHARED_TRACE_INIT(session, "macro_trace2");
+  SHARED_TRACE_START("macro_trace1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  SHARED_TRACE_END("macro_trace1");
+  SHARED_TRACE_START("macro_trace2");
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  SHARED_TRACE_END("macro_trace2");
+  session.stop();
+  std::ifstream file("test_macro_trace.log");
+  ASSERT_TRUE(file.is_open());
+  std::string line;
+  int count = 0;
+  while (std::getline(file, line)) {
+    EXPECT_FALSE(line.empty());
+    ++count;
+  }
+  EXPECT_EQ(count, 2);
+  file.close();
+  std::remove("test_macro_trace.log");
 }
 
 int main(int argc, char ** argv)

--- a/tests/yaets_test.cpp
+++ b/tests/yaets_test.cpp
@@ -4,7 +4,8 @@
 #include <thread>
 #include <chrono>
 
-class TraceGuardTest : public yaets::TraceGuard {
+class TraceGuardTest : public yaets::TraceGuard
+{
 public:
   TraceGuardTest(yaets::TraceSession & session, const std::string & trace_name)
   : TraceGuard(session, trace_name) {}

--- a/tests/yaets_test.cpp
+++ b/tests/yaets_test.cpp
@@ -27,7 +27,8 @@ TEST(yaets, TraceSessionInitStop) {
 
 TEST(yaets, TraceSessionWriteEvent) {
   yaets::TraceSession trace_session("test_trace_event.log");
-  trace_session.register_trace("testFunction", std::chrono::nanoseconds(100),
+  trace_session.register_trace(
+    "testFunction", std::chrono::nanoseconds(100),
     std::chrono::nanoseconds(200));
   trace_session.stop();
   std::ifstream file("test_trace_event.log");


### PR DESCRIPTION
Hi,

This PR:

- adds the option to have traces that start in one function and end in another.

Example:

```
class SensorDriverNode : public rclcpp::Node
{
  ...
  void produce_data()
  {
    SHARED_TRACE_START("brake_process");
    waste_time(shared_from_this(), 200us);

    sensor_msgs::msg::Image image_msg;
    pub_->publish(image_msg);
  }
...
class BrakeActuatorNode : public rclcpp::Node
{
  ...
  void react_obstacle(vision_msgs::msg::Detection3D::SharedPtr msg)
  {
    waste_time(shared_from_this(), 2ms);
    SHARED_TRACE_END("brake_process");
  } 
...
int main(int argc, char * argv[])
{
  ...
  SHARED_TRACE_INIT(session, "brake_process");
```

- Add a new visualization script for displaying histograms of the execution time

Best