### PR TITLE
Add CMake export targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,13 @@ set(version 0.1)
 set(CMAKE_CXX_STANDARD 17)
 find_package(ament_cmake REQUIRED)
 
-include_directories(include)
 add_library(${PROJECT_NAME} SHARED
-  src/yaets/tracing.cpp)
+  src/yaets/tracing.cpp
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 
 install(DIRECTORY include/
@@ -23,6 +27,7 @@ install(PROGRAMS
 
 install(TARGETS
   ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -42,5 +47,6 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
This PR updates the CMake to export the library target so it can be properly consumed from other packages without `ament_target_dependencies`.